### PR TITLE
Fix null dereference in manual update check

### DIFF
--- a/pass-winmenu/src/Program.cs
+++ b/pass-winmenu/src/Program.cs
@@ -186,7 +186,7 @@ namespace PassWinmenu
 				.AsSelf()
 				.SingleInstance();
 
-			builder.Register(context => UpdateCheckerFactory.CreateUpdateChecker(context.Resolve<UpdateCheckingConfig>(), context.Resolve<INotificationService>()));
+			builder.Register(context => UpdateCheckerFactory.CreateUpdateChecker(context.Resolve<UpdateCheckingConfig>(), context.Resolve<INotificationService>())).SingleInstance();
 			builder.RegisterType<RemoteUpdateCheckerFactory>().AsSelf();
 			builder.Register(context => context.Resolve<RemoteUpdateCheckerFactory>().Build()).AsSelf();
 

--- a/pass-winmenu/src/UpdateChecking/UpdateChecker.cs
+++ b/pass-winmenu/src/UpdateChecking/UpdateChecker.cs
@@ -17,7 +17,7 @@ namespace PassWinmenu.UpdateChecking
 
 		public event EventHandler<UpdateAvailableEventArgs> UpdateAvailable;
 
-		private Timer timer;
+		private Timer? timer;
 
 		public UpdateChecker(IUpdateSource   updateSource,
 		                     SemanticVersion currentVersion,
@@ -76,8 +76,8 @@ namespace PassWinmenu.UpdateChecking
 			}
 
 			// Stop automatic update checking if we've found an update.
-			timer.Stop();
-			timer.Dispose();
+			timer?.Stop();
+			timer?.Dispose();
 			Log.Send($"New update found: {update.Value.VersionNumber} - prerelease: {update.Value.IsPrerelease} - important: {update.Value.Important}", LogLevel.Debug);
 			NotifyUpdate(update.Value);
 			return true;


### PR DESCRIPTION
The manual update check receives a fresh instance of `UpdateChecker` from dependency injection, which does not have the timer set. Fix this by changing it to a singleton. In addition, make it explicit that the timer may be null if the automatic update checker is never started.