### PR TITLE
Fix file name extension in $filename value

### DIFF
--- a/pass-winmenu/src/Actions/AddPasswordAction.cs
+++ b/pass-winmenu/src/Actions/AddPasswordAction.cs
@@ -50,7 +50,7 @@ namespace PassWinmenu.Actions
 			// Display the password generation window.
 			string password;
 			string metadata;
-			using (var passwordWindow = new PasswordWindow(Path.GetFileName(passwordFilePath), ConfigManager.Config.PasswordStore.PasswordGeneration))
+			using (var passwordWindow = new PasswordWindow(Path.GetFileNameWithoutExtension(passwordFilePath), ConfigManager.Config.PasswordStore.PasswordGeneration))
 			{
 				passwordWindow.ShowDialog();
 				if (!passwordWindow.DialogResult.GetValueOrDefault())


### PR DESCRIPTION
Configuration file describes $filename variable as the new file name without path and without extension, but the new file dialog always shows metadata with the variable replaced by the filename with the extension. Path.GetFileName function was called to obtain the $filename value but it leaves the extension untouched. I propose Path.GetFileNameWithoutExtension be called instead. Here is the screenshot of the issue:
![pass-winmenu-bug](https://user-images.githubusercontent.com/102019268/230199179-a22c9b72-d5da-40d0-8066-b8cf668a6a00.png)
