### PR TITLE
Prevent saving unmodified content

### DIFF
--- a/pass-winmenu/src/Windows/EditWindow.xaml
+++ b/pass-winmenu/src/Windows/EditWindow.xaml
@@ -23,7 +23,7 @@
 			<Grid DockPanel.Dock="Top">
 				<TextBox x:Name="PasswordContent" Margin="10,10,10,45" Padding="3,3,3,3" TextWrapping="Wrap" AcceptsReturn="True"
 				         AcceptsTab="True" CaretIndex="10" FontFamily="Consolas" GotFocus="HandlePasswordContentFocus"
-				         LostFocus="HandlePasswordContentFocus">
+				         LostFocus="HandlePasswordContentFocus" TextChanged="PasswordContent_TextChanged">
 				</TextBox>
 				<Rectangle x:Name="PasswordDivider" Stroke="#569de5" Margin="10,28,10,0" StrokeThickness="1" StrokeDashArray="2 3" Height="1" VerticalAlignment="Top" />
 			</Grid>

--- a/pass-winmenu/src/Windows/EditWindow.xaml.cs
+++ b/pass-winmenu/src/Windows/EditWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace PassWinmenu.Windows
 	internal sealed partial class EditWindow
 	{
 		private readonly PasswordGenerator passwordGenerator;
+		private readonly string originalContent;
 
 		public EditWindow(string path, string content, PasswordGenerationConfig options)
 		{
@@ -23,6 +24,8 @@ namespace PassWinmenu.Windows
 			CreateCheckboxes();
 
 			Title = $"Editing '{path}'";
+
+			originalContent = content.Replace(Environment.NewLine, "\n");
 
 			PasswordContent.Text = content;
 			PasswordContent.Focus();
@@ -104,6 +107,11 @@ namespace PassWinmenu.Windows
 			{
 				PasswordDivider.Stroke = new SolidColorBrush(Color.FromRgb(171, 173, 179));
 			}
+		}
+
+		private void PasswordContent_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			Btn_OK.IsEnabled = PasswordContent.Text.Replace(Environment.NewLine, "\n") != originalContent;
 		}
 	}
 }


### PR DESCRIPTION
This is targeting the case when a user types the password in generator's textbox by mistake thinking it will be saved to the file. It will not be saved in the case, the meaningless git commit will be created and the user if don't have a copy of the password will not be able to see it again. The notification helps to avoid loosing the password.