### PR TITLE
Terminate lines of an edited file with \n

### DIFF
--- a/pass-winmenu/src/Actions/EditPasswordAction.cs
+++ b/pass-winmenu/src/Actions/EditPasswordAction.cs
@@ -82,7 +82,7 @@ namespace PassWinmenu.Actions
 				return;
 			}
 
-			var newFile = new DecryptedPasswordFile(file, window.PasswordContent.Text);
+			var newFile = new DecryptedPasswordFile(file, window.PasswordContent.Text.Replace(Environment.NewLine, "\n"));
 			try
 			{
 				passwordManager.EncryptPassword(newFile);


### PR DESCRIPTION
This approach is implemented for new files. Let's conform the approaches with each other.

When a user creates a new file and puts there metadata right away, the line endings will be forced to be '\n'. If a user creates a new file without metadata and adds it later by editing the file, the line endings will be left Environment.NewLine. A user probably expects the files to be the same which is not the case.
